### PR TITLE
fix: remove unused C file

### DIFF
--- a/ldk_node/ldk_node.c
+++ b/ldk_node/ldk_node.c
@@ -1,8 +1,0 @@
-#include <ldk_node.h>
-
-// This file exists beacause of
-// https://github.com/golang/go/issues/11263
-
-void cgo_rust_task_callback_bridge_ldk_node(RustTaskCallback cb, const void * taskData, int8_t status) {
-  cb(taskData, status);
-}


### PR DESCRIPTION
The file is no longer generated by uniffi-bindgen-go v0.3.0, and in fact its presence breaks the build.